### PR TITLE
Update the table headings in kubectl-pi plugin output

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ Warning  PodInteraction  21s   kube-exec-controller  Pod will be evicted at time
 You can also utilize the `kubectl pi` plugin to get more detailed info or request an extension to the test Pod's eviction time:
 ```
 $ kubectl pi get
-POD_NAME  INTERACTOR        POD_TTL  EXTENSION  EXTENSION_REQUESTER  EVICTION_TIME
+POD-NAME  INTERACTOR        POD-TTL  EXTENSION  EXTENSION-REQUESTER  EVICTION-TIME
 test      kubernetes-admin  2m0s                                     2021-10-16 18:06:44 +0000 UTC
 
 $ kubectl pi extend --duration=1m
 Successfully extended the termination time of pod/test with a duration=1m
 
 $ kubectl pi get
-POD_NAME  INTERACTOR        POD_TTL  EXTENSION  EXTENSION_REQUESTER  EVICTION_TIME
+POD-NAME  INTERACTOR        POD-TTL  EXTENSION  EXTENSION-REQUESTER  EVICTION-TIME
 test      kubernetes-admin  2m0s     1m         kubernetes-admin     2021-10-16 18:07:44 +0000 UTC
 
 $ kubectl describe pod test

--- a/pkg/plugin/pi.go
+++ b/pkg/plugin/pi.go
@@ -219,7 +219,7 @@ func (o *CmdOptions) printTable(infoList []PodInteractionInfo) error {
 	w := new(tabwriter.Writer)
 	// format in tab-separated columns with a tab stop of 8
 	w.Init(o.Out, 0, 8, 2, '\t', 0)
-	fmt.Fprintln(w, "POD_NAME\tINTERACTOR\tPOD_TTL\tEXTENSION\tEXTENSION_REQUESTER\tEVICTION_TIME")
+	fmt.Fprintln(w, "POD-NAME\tINTERACTOR\tPOD-TTL\tEXTENSION\tEXTENSION-REQUESTER\tEVICTION-TIME")
 	for _, info := range infoList {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s",
 			info.podName,


### PR DESCRIPTION
Replacing the `_` to `-` between multiple words in table headings as it's the default in native kubectl command's output (also pointed out by @sftim in the review of [blog post PR](https://github.com/kubernetes/website/pull/29761/files#r757945821)).